### PR TITLE
Added Eclipse Che job template for duffy node initialization

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -863,7 +863,7 @@
             set +e
 
             export CICO_API_KEY=$(cat ~/duffy.key )
-
+            cp ~/artifacts.key .
             get_cico_node() {{
                 # get node
                 n=1
@@ -1621,19 +1621,13 @@
         <<: *vault_defaults
         secret:
             - *quay-eclipse-che-credentials
-    trigger:
-            - github
-            
-    <<: *job_template_defaults
+            - *eclipse-che-oss-sonatype 
+    <<: *job_template_build_defaults
     
 - job-template:
     name: '{ci_project}-{git_repo}-che-nightly-test-master'
-    wrappers:
-    - vault-secrets:
-        <<: *vault_defaults
-        secrets: 
-            - *quay-eclipse-che-credentials
-
+    triggers:
+        - timed: 'H 0 * * *'
     <<: *eclipse-che-automation-template
 
 


### PR DESCRIPTION
If I didn't break anything, this should work for you.

Default github trrigger is present in the `job_template_build_defaults` template.

Credentials are set in the `eclipse-che-automation-template` template, if job needs a specific extra credential, you can always add it

Job also has a specific trigger, which should execute it at `0:<random_minute>am` of the ci.centos.org server which is UTC timezone, so you should have your results before every midnight as well. 